### PR TITLE
return a promise from play, but only if the browser supports it

### DIFF
--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1066,6 +1066,84 @@ QUnit.test('should be scrubbing while seeking', function(assert) {
   player.dispose();
 });
 
+if (typeof window.Promise !== 'undefined') {
+  QUnit.test('play should return a promise if they are supported', function(assert) {
+    const player = TestHelpers.makePlayer({});
+    const p = player.play();
+
+    assert.ok(p, 'play returns something');
+    assert.equal(typeof p.then, 'function', 'play returns a promise');
+
+    player.dispose();
+  });
+
+  QUnit.test('play promise should resolve to native promise if returned', function(assert) {
+    const player = TestHelpers.makePlayer({});
+    const done = assert.async();
+
+    player.tech_.play = () => window.Promise.resolve('foo');
+    const p = player.play();
+
+    assert.ok(p, 'play returns something');
+    assert.equal(typeof p.then, 'function', 'play returns a promise');
+    p.then(function(val) {
+      assert.equal(val, 'foo', 'should resolve to native promise value');
+
+      player.dispose();
+      done();
+    });
+
+  });
+
+  QUnit.test('play promise should resolve to native value if returned', function(assert) {
+    const player = TestHelpers.makePlayer({});
+    const done = assert.async();
+
+    player.tech_.play = () => 'foo';
+    const p = player.play();
+
+    assert.ok(p, 'play returns something');
+    assert.equal(typeof p.then, 'function', 'play returns a promise');
+    p.then(function(val) {
+      assert.equal(val, 'foo', 'should resolve to native promise value');
+
+      player.dispose();
+      done();
+    });
+  });
+
+  QUnit.test('play promise should resolve to undefined value if returned', function(assert) {
+    const player = TestHelpers.makePlayer({});
+    const done = assert.async();
+
+    player.tech_.play = () => undefined;
+    const p = player.play();
+
+    assert.ok(p, 'play returns something');
+    assert.equal(typeof p.then, 'function', 'play returns a promise');
+    p.then(function(val) {
+      assert.equal(val, undefined, 'should resolve to undefined');
+
+      player.dispose();
+      done();
+    });
+  });
+}
+
+QUnit.test('play should not return a promise if they are not supported', function(assert) {
+  const oldPromise = window.Promise;
+
+  window.Promise = null;
+
+  const player = TestHelpers.makePlayer({});
+  const p = player.play();
+
+  assert.notOk(p, 'play returns nothing');
+
+  player.dispose();
+  window.Promise = oldPromise;
+});
+
 QUnit.test('should throw on startup no techs are specified', function(assert) {
   const techOrder = videojs.options.techOrder;
 


### PR DESCRIPTION
## Description
Return a Promise from play if we can. Based on https://github.com/videojs/video.js/pull/3860


## Specific Changes proposed
* make the play function in the html5 tech return the value of `this.el_.play()`
* wrap around the play function in `player.play()` so that it resolves a Promise to the return value of that call (if supported). This means that we will  
  * Always return a Promise if there is support for it
  * Resolve to the native promise if it is around
  * Have the old functionality on browsers that don't support promises.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
- [ ] Reviewed by Two Core Contributors

